### PR TITLE
setupSleep function and verify with wakeOrSleep function

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun MMA8452Q Accelerometer
-version=1.4.0
+version=1.5.0
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Basic I2C functionality of the <a href="https://www.sparkfun.com/products/14587">MMA8452Q Accelerometer Breakout</a>

--- a/src/SparkFun_MMA8452Q.h
+++ b/src/SparkFun_MMA8452Q.h
@@ -146,6 +146,9 @@ class MMA8452Q
 	void setScale(MMA8452Q_Scale fsr);
 	void setDataRate(MMA8452Q_ODR odr);
 
+	bool setupSleep(bool enable = 1, bool firstPin = 0, uint8_t ovr = 1, uint8_t ssr = 0, uint8_t wsr = 0, uint8_t timeout = 1);
+	uint8_t wakeOrSleep();
+
   private:
 	TwoWire *_i2cPort = NULL; //The generic connection to user's chosen I2C hardware
 	uint8_t _deviceAddress;   //Keeps track of I2C address. setI2CAddress changes this.


### PR DESCRIPTION
Hello there,

I don't have instruments to verify that the device is sleeping,although the function wakeOrSleep reports that the device is sleeping. It would be nice if you can verify that the command is working.

I discovered a bug (?).
`  accel.setupSleep();` works fine. But If I enable oversampling (example: `accel.setupSleep(1,0,1,0,5,1)` then the devices does not sleep, unless the `accel.setupSleep() (with default parameters) is issued first.

So if after init we have `accel.setupSleep(1,0,1,0,5,1)`, device seems that does not sleep.

but with
```
accel.setupSleep();
delay(1000);
accel.setupSleep(1,0,1,0,5,1);
```
...seems fine

I am newbie programmer,so please have patience with me :-)

Have a nice day.