### PR TITLE
set scale factor in the object as well

### DIFF
--- a/src/SparkFun_MMA8452Q.cpp
+++ b/src/SparkFun_MMA8452Q.cpp
@@ -196,6 +196,9 @@ void MMA8452Q::setScale(MMA8452Q_Scale fsr)
 	cfg |= (fsr >> 2); // Neat trick, see page 22. 00 = 2G, 01 = 4A, 10 = 8G
 	writeRegister(XYZ_DATA_CFG, cfg);
 
+	// Set scale factor 
+	scale = fsr
+
 	// Return to active state when done
 	// Must be in active state to read data
 	active();

--- a/src/SparkFun_MMA8452Q.cpp
+++ b/src/SparkFun_MMA8452Q.cpp
@@ -197,7 +197,7 @@ void MMA8452Q::setScale(MMA8452Q_Scale fsr)
 	writeRegister(XYZ_DATA_CFG, cfg);
 
 	// Set scale factor 
-	scale = fsr
+	scale = fsr;
 
 	// Return to active state when done
 	// Must be in active state to read data


### PR DESCRIPTION
Dear all,

First of all thanks for this library (and allowing me to add some "advanced" telemetry to the kids' waterrocket :)) I noticed when playing with the setScale() function, that the readings for getCalculatedX(), etc changed by a similar factor, which I assume shouldn't happen as they are in units of g. 

Shouldn't the the "scale" factor also be set in the setScale() function in addition to the hardware configuration of the sensor itself ? That way the scale is correctly taken into account in the getCalculatedX(), .... functions. Or perhaps I'm missing something. 

Cheers,
bino 