### PR TITLE
Support for building as an ESP-IDF component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,11 @@
+# Sparkfun SparkFun_MMA8452Q Library
+# https://github.com/sparkfun/SparkFun_MMA8452Q_Arduino_Library
+# Beerware License
+
+cmake_minimum_required(VERSION 3.5)
+
+idf_component_register(SRCS "src/SparkFun_MMA8452Q.cpp"
+                       INCLUDE_DIRS "src"
+                       REQUIRES arduino)
+
+project(SparkFun_MMA8452Q)


### PR DESCRIPTION
This PR adds the required `CMakeLists.txt` file to enable building as an ESP-IDF component (e.g. in `components/SparkFun_MMA8452Q`)

Similar [PR on Adafruit-GFX-Library](https://github.com/adafruit/Adafruit-GFX-Library/pull/376/files).